### PR TITLE
fix test for PHP 7.4

### DIFF
--- a/tests/reflection.phpt
+++ b/tests/reflection.phpt
@@ -32,13 +32,13 @@ function print_method_summary(ReflectionClass $class, string $method)
     printf("%s\n", $method->getName());
     printf("Number of parameters: %d\n", $method->getNumberOfParameters());
     printf("Number of required parameters: %d\n", $method->getNumberOfRequiredParameters());
-    printf("Return type: %s\n", $method->hasReturnType() ? $method->getReturnType() : "void");
+    printf("Return type: %s\n", $method->hasReturnType() ? (PHP_VERSION_ID >= 70100 ? $method->getReturnType()->getName() : (string) $method->getReturnType()) : "void");
     printf("Allows return null? %s\n", $method->hasReturnType() ? ($method->getReturnType()->allowsNull() ? "yes" : "no") : "no");
     printf("Returns reference? %s\n", $method->returnsReference() ? "yes" : "no");
     printf("Parameters:\n");
     foreach ($method->getParameters() as $parameter) {
         printf("Name: %s\n", $parameter->getName());
-        printf("Type: %s\n", ((string) $parameter->getType()) ?: "mixed");
+        printf("Type: %s\n", ($parameter->hasType() ? (PHP_VERSION_ID >= 70100 ? $parameter->getType()->getName() : (string) $parameter->getType()) : "mixed"));
         printf("Reference? %s\n", $parameter->isPassedByReference() ? "yes" : "no");
         printf("Allows null? %s\n", $parameter->allowsNull() ? "yes" : "no");
         printf("Optional? %s\n", $parameter->isOptional() ? "yes" : "no");


### PR DESCRIPTION
Without:

```
TEST 48/49 [tests/reflection.phpt]
========DIFF========
044+ 
045+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 34
054+ 
055+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
064+ 
065+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
079+ 
080+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
094+ 
095+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
109+ 
110+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
124+ 
125+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
139+ 
140+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
154+ 
155+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
169+ 
170+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
179+ 
180+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
189+ 
190+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
199+ 
200+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
209+ 
210+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
219+ 
220+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
229+ 
230+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
239+ 
240+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
246+ 
247+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 34
253+ 
254+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 34
263+ 
264+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
270+ 
271+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 34
280+ 
281+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
290+ 
291+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
300+ 
301+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
310+ 
311+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
320+ 
321+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
330+ 
331+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
340+ 
341+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
350+ 
351+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
360+ 
361+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
370+ 
371+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
380+ 
381+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
390+ 
391+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
400+ 
401+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
410+ 
411+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
417+ 
418+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 34
424+ 
425+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 34
431+ 
432+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 34
441+ 
442+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
451+ 
452+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
461+ 
462+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
471+ 
472+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
486+ 
487+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
501+ 
502+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
513+ 
514+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 34
523+ 
524+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
535+ 
536+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 34
545+ 
546+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
555+ 
556+ Deprecated: Function ReflectionType::__toString() is deprecated in /work/GIT/decimal/tests/reflection.php on line 28
========DONE========

```