### PR TITLE
Add missing source file to extension for Windows

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -2,7 +2,8 @@
 // vim:ft=javascript
 
 var DECIMAL_EXT_NAME        ="decimal";
-var DECIMAL_EXT_API         ="php_decimal.c src/common.c src/compare.c src/context.c src/convert.c src/decimal.c src/errors.c src/globals.c src/math.c src/number.c src/parse.c src/rational.c src/round.c";
+var DECIMAL_EXT_API         ="php_decimal.c";
+var DECIMAL_ADD_SOURCES     ="common.c compare.c context.c convert.c decimal.c errors.c globals.c math.c number.c parse.c rational.c round.c"
 var DECIMAL_EXT_DEP_HEADER  ="mpdecimal.h";
 var DECIMAL_EXT_FLAGS       ="/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1";
 var DECIMAL_EXT_DEP_LIB_SHARED ="libmpdec.lib";
@@ -27,6 +28,7 @@ if (PHP_DECIMAL == "yes") {
 
     if (setup_ok) {
         EXTENSION(DECIMAL_EXT_NAME, DECIMAL_EXT_API, PHP_DECIMAL_SHARED, DECIMAL_EXT_FLAGS);
+        ADD_SOURCES(configure_module_dirname + "\\src", DECIMAL_ADD_SOURCES, DECIMAL_EXT_NAME);
         if (libmpdec_shared) {
             ADD_FLAG("CFLAGS_DECIMAL", "/D USE_DLL=1");
         }

--- a/config.w32
+++ b/config.w32
@@ -2,7 +2,7 @@
 // vim:ft=javascript
 
 var DECIMAL_EXT_NAME        ="decimal";
-var DECIMAL_EXT_API         ="php_decimal.c";
+var DECIMAL_EXT_API         ="php_decimal.c src/common.c src/compare.c src/context.c src/convert.c src/decimal.c src/errors.c src/globals.c src/math.c src/number.c src/parse.c src/rational.c src/round.c";
 var DECIMAL_EXT_DEP_HEADER  ="mpdecimal.h";
 var DECIMAL_EXT_FLAGS       ="/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1";
 var DECIMAL_EXT_DEP_LIB_SHARED ="libmpdec.lib";


### PR DESCRIPTION
These sources are already catered to in config.m4, but apparently,
config.w32 has been overlooked.