### PR TITLE
Fix registering object handlers on PHP 8.3

### DIFF
--- a/php_decimal.c
+++ b/php_decimal.c
@@ -358,7 +358,9 @@ static php_decimal_t *php_decimal_alloc()
     php_decimal_t *obj = ecalloc(1, sizeof(php_decimal_t));
 
     if (obj) {
+#if PHP_VERSION_ID < 80300
         obj->std.handlers = &php_decimal_handlers;
+#endif
         zend_object_std_init((zend_object *) obj, php_decimal_ce);
     } else {
         php_decimal_memory_error();
@@ -2745,6 +2747,10 @@ static void php_decimal_register_class_entry()
     php_decimal_ce->create_object  = php_decimal_create_object;
     php_decimal_ce->serialize      = php_decimal_serialize;
     php_decimal_ce->unserialize    = php_decimal_unserialize;
+
+#if PHP_VERSION_ID >= 80300
+    php_decimal_ce->default_object_handlers = &php_decimal_handlers;
+#endif
 
     zend_class_implements(php_decimal_ce, 1, php_json_serializable_ce);
 

--- a/tests/php8.1/methods/__construct.phpt
+++ b/tests/php8.1/methods/__construct.phpt
@@ -2,7 +2,7 @@
 Decimal::__construct
 --SKIPIF--
 <?php
-if (!extension_loaded("decimal") || PHP_VERSION_ID < 80000 || PHP_VERSION_ID >= 80100) echo "skip";
+if (!extension_loaded("decimal") || PHP_VERSION_ID < 81000) echo "skip";
 ?>
 --FILE--
 <?php
@@ -136,6 +136,8 @@ B Failed to parse string as decimal: "1 "
 C Decimal\Decimal::__construct() expected parameter 1 to be a string, integer, or decimal, float given
 D Decimal\Decimal::__construct() expected parameter 1 to be a string, integer, or decimal, null given
 E Decimal\Decimal::__construct(): Argument #2 ($precision) must be of type int, string given
+
+Deprecated: Decimal\Decimal::__construct(): Passing null to parameter #2 ($precision) of type int is deprecated in /work/php-decimal/ext-decimal/tests/php8/methods/__construct.php on line 92
 F Decimal precision out of range
 G Decimal precision out of range
 H Decimal precision out of range


### PR DESCRIPTION
PHP 8.3 introduced some changes to how object handlers are registered.

Quote from UPGRADING.INTERNALS:
> *zend_class_entry now possesses a default_object_handlers field, which provides a default object handler when create_object() is not overriding it.*

This fix rougly mimics the change done in bundled PHP extensions in this commit: https://github.com/php/php-src/commit/94ee4f9834743ca74f6c9653863273277ce6c61a while keeping pre-8.3 compatibility.

I've also split the constructor test for PHP <8.1 and >=PHP 8.1 since there's a deprecation emitted by PHP as of PHP 8.1:
> *Deprecated: Decimal\Decimal::__construct(): Passing null to parameter #2 ($precision) of type int is deprecated in /work/php-decimal/ext-decimal/tests/php8/methods/__construct.php on line 92*

The tests should be green an all PHP 7.4-8.3 (didn't test older versions).

closes #77